### PR TITLE
feat: Add include and exclude option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,11 @@ export interface IPreactRefreshRspackPluginOptions {
   };
 }
 
+interface NormalizedPluginOptions extends IPreactRefreshRspackPluginOptions {
+  include: NonNullable<IPreactRefreshRspackPluginOptions['include']>;
+  exclude: NonNullable<IPreactRefreshRspackPluginOptions['exclude']>;
+}
+
 const PREACT_PATHS = [
   'preact',
   'preact/compat',
@@ -56,8 +61,9 @@ const NAME = 'PreactRefreshRspackPlugin';
 
 class PreactRefreshRspackPlugin implements RspackPluginInstance {
   name = NAME;
+  private options: NormalizedPluginOptions;
 
-  constructor(private options: IPreactRefreshRspackPluginOptions) {
+  constructor(options: IPreactRefreshRspackPluginOptions) {
     this.options = {
       include: options?.include ?? /\.([jt]sx?)$/,
       exclude: options?.exclude ?? /node_modules/,
@@ -93,7 +99,6 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
     compiler.options.module.rules.unshift({
       include: this.options.include,
       exclude: {
-
         or: [this.options.exclude, ...INTERNAL_PATHS].filter(Boolean),
       },
       use: 'builtin:preact-refresh-loader',

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import fs from 'node:fs';
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
 
 export interface IPreactRefreshRspackPluginOptions {
+  include?: string | RegExp | (string | RegExp)[] | null;
+  exclude?: string | RegExp | (string | RegExp)[] | null;
   overlay?: {
     module: string;
   };
@@ -57,6 +59,8 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
 
   constructor(private options: IPreactRefreshRspackPluginOptions) {
     this.options = {
+      include: options?.include ?? /\.([jt]sx?)$/,
+      exclude: options?.exclude ?? /node_modules/,
       overlay: options?.overlay,
     };
   }
@@ -87,9 +91,10 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
       ...compiler.options.resolve.alias,
     };
     compiler.options.module.rules.unshift({
-      include: /\.([jt]sx?)$/,
+      include: this.options.include,
       exclude: {
-        or: [/node_modules/, ...INTERNAL_PATHS].filter(Boolean),
+
+        or: [this.options.exclude, ...INTERNAL_PATHS].filter(Boolean),
       },
       use: 'builtin:preact-refresh-loader',
     });

--- a/test/Config.test.js
+++ b/test/Config.test.js
@@ -1,0 +1,5 @@
+const { describeByWalk, createConfigCase } = require('@rspack/test-tools');
+
+describeByWalk(__filename, (name, src, dist) => {
+  createConfigCase(name, src, dist);
+});

--- a/test/configCases/.gitignore
+++ b/test/configCases/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/test/configCases/condition/exclude/file.js
+++ b/test/configCases/condition/exclude/file.js
@@ -1,0 +1,1 @@
+require("foo");

--- a/test/configCases/condition/exclude/index.js
+++ b/test/configCases/condition/exclude/index.js
@@ -1,0 +1,7 @@
+require('./file');
+
+it("should exclude selected file when compiling", done => {
+  expect(__webpack_modules__[require.resolve('./file.js')].toString())
+    .not.toContain('__prefresh_utils__');
+  done();
+});

--- a/test/configCases/condition/exclude/rspack.config.js
+++ b/test/configCases/condition/exclude/rspack.config.js
@@ -1,0 +1,11 @@
+const ReactRefreshRspackPlugin = require('../../../..');
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  mode: 'development',
+  context: __dirname,
+  entry: './index.js',
+  plugins: [new ReactRefreshRspackPlugin({
+    exclude: /file\.js/,
+  })],
+};

--- a/test/configCases/condition/exclude/rspack.config.js
+++ b/test/configCases/condition/exclude/rspack.config.js
@@ -3,6 +3,7 @@ const ReactRefreshRspackPlugin = require('../../../..');
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
   mode: 'development',
+  target: 'web',
   context: __dirname,
   entry: './index.js',
   plugins: [new ReactRefreshRspackPlugin({

--- a/test/configCases/condition/include/file.js
+++ b/test/configCases/condition/include/file.js
@@ -1,0 +1,1 @@
+require("foo");

--- a/test/configCases/condition/include/index.js
+++ b/test/configCases/condition/include/index.js
@@ -1,0 +1,7 @@
+require('./file');
+
+it("should include selected file when compiling", done => {
+  expect(__webpack_modules__[require.resolve('foo')].toString())
+    .toContain('__prefresh_utils__');
+  done();
+});

--- a/test/configCases/condition/include/rspack.config.js
+++ b/test/configCases/condition/include/rspack.config.js
@@ -3,6 +3,7 @@ const ReactRefreshRspackPlugin = require('../../../..');
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
   mode: 'development',
+  target: 'web',
   context: __dirname,
   entry: './index.js',
   plugins: [new ReactRefreshRspackPlugin({

--- a/test/configCases/condition/include/rspack.config.js
+++ b/test/configCases/condition/include/rspack.config.js
@@ -1,0 +1,12 @@
+const ReactRefreshRspackPlugin = require('../../../..');
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  mode: 'development',
+  context: __dirname,
+  entry: './index.js',
+  plugins: [new ReactRefreshRspackPlugin({
+    exclude: /$^/,  // match nothing
+    include: /foo/,
+  })],
+};

--- a/test/configCases/node_modules/foo/index.js
+++ b/test/configCases/node_modules/foo/index.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/test/configCases/node_modules/foo/package.json
+++ b/test/configCases/node_modules/foo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "foo",
+  "main": "./index.js"
+}


### PR DESCRIPTION
This PR aims to add the `include` and `exclude` option like the `@rspack/plugin-react-refresh`.

These options are helpful when works with `svgr` and `mdx`, or prevent runtime injection to other packages sharing the same workspace.