### PR TITLE
fix: reduce alias and allow to use esm bundles of preact

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2",
+    "ignorePaths": [],
+    "dictionaryDefinitions": [],
+    "dictionaries": [],
+    "words": [
+        "prefresh",
+        "preact"
+    ],
+    "ignoreWords": [],
+    "import": []
+}

--- a/test/hotCases/hook/useContext#initial/__snapshots__/web/1.snap.txt
+++ b/test/hotCases/hook/useContext#initial/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 5266
+- Update: main.LAST_HASH.hot-update.js, size: 5127
 
 ## Manifest
 
@@ -38,9 +38,8 @@ __webpack_require__.d(__webpack_exports__, {
   App: function() { return App; }
 });
 /* ESM import */var react_jsx_dev_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react/jsx-dev-runtime */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/compat/jsx-dev-runtime.js");
-/* ESM import */var preact_compat__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! preact/compat */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/compat/dist/compat.js");
-/* ESM import */var preact_compat__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(preact_compat__WEBPACK_IMPORTED_MODULE_1__);
-/* ESM import */var preact_hooks__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! preact/hooks */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/hooks/dist/hooks.js");
+/* ESM import */var preact_compat__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! preact/compat */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/compat/dist/compat.module.js");
+/* ESM import */var preact_hooks__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! preact/hooks */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/hooks/dist/hooks.module.js");
 /* module decorator */ module = __webpack_require__.hmd(module);
 /* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../client/prefresh.cjs */ "../../../../client/prefresh.cjs");
 

--- a/test/hotCases/hook/useContext#keep/__snapshots__/web/1.snap.txt
+++ b/test/hotCases/hook/useContext#keep/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 5571
+- Update: main.LAST_HASH.hot-update.js, size: 5432
 
 ## Manifest
 
@@ -38,9 +38,8 @@ __webpack_require__.d(__webpack_exports__, {
   App: function() { return App; }
 });
 /* ESM import */var react_jsx_dev_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react/jsx-dev-runtime */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/compat/jsx-dev-runtime.js");
-/* ESM import */var preact_compat__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! preact/compat */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/compat/dist/compat.js");
-/* ESM import */var preact_compat__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(preact_compat__WEBPACK_IMPORTED_MODULE_1__);
-/* ESM import */var preact_hooks__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! preact/hooks */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/hooks/dist/hooks.js");
+/* ESM import */var preact_compat__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! preact/compat */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/compat/dist/compat.module.js");
+/* ESM import */var preact_hooks__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! preact/hooks */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/hooks/dist/hooks.module.js");
 /* module decorator */ module = __webpack_require__.hmd(module);
 /* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../client/prefresh.cjs */ "../../../../client/prefresh.cjs");
 

--- a/test/hotCases/hook/useContext#provide/__snapshots__/web/1.snap.txt
+++ b/test/hotCases/hook/useContext#provide/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 5587
+- Update: main.LAST_HASH.hot-update.js, size: 5448
 
 ## Manifest
 
@@ -38,9 +38,8 @@ __webpack_require__.d(__webpack_exports__, {
   App: function() { return App; }
 });
 /* ESM import */var react_jsx_dev_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react/jsx-dev-runtime */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/compat/jsx-dev-runtime.js");
-/* ESM import */var preact_compat__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! preact/compat */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/compat/dist/compat.js");
-/* ESM import */var preact_compat__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(preact_compat__WEBPACK_IMPORTED_MODULE_1__);
-/* ESM import */var preact_hooks__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! preact/hooks */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/hooks/dist/hooks.js");
+/* ESM import */var preact_compat__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! preact/compat */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/compat/dist/compat.module.js");
+/* ESM import */var preact_hooks__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! preact/hooks */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/hooks/dist/hooks.module.js");
 /* module decorator */ module = __webpack_require__.hmd(module);
 /* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../client/prefresh.cjs */ "../../../../client/prefresh.cjs");
 

--- a/test/hotCases/hook/useState#keep/__snapshots__/web/1.snap.txt
+++ b/test/hotCases/hook/useState#keep/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 4697
+- Update: main.LAST_HASH.hot-update.js, size: 4704
 
 ## Manifest
 
@@ -39,7 +39,7 @@ __webpack_require__.d(__webpack_exports__, {
 });
 /* ESM import */var _swc_helpers_sliced_to_array__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @swc/helpers/_/_sliced_to_array */ "../../../../node_modules/.pnpm/@swc+helpers@0.5.13/node_modules/@swc/helpers/esm/_sliced_to_array.js");
 /* ESM import */var react_jsx_dev_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react/jsx-dev-runtime */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/compat/jsx-dev-runtime.js");
-/* ESM import */var preact_hooks__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! preact/hooks */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/hooks/dist/hooks.js");
+/* ESM import */var preact_hooks__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! preact/hooks */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/hooks/dist/hooks.module.js");
 /* module decorator */ module = __webpack_require__.hmd(module);
 /* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../client/prefresh.cjs */ "../../../../client/prefresh.cjs");
 

--- a/test/hotCases/hook/useState#reset/__snapshots__/web/1.snap.txt
+++ b/test/hotCases/hook/useState#reset/__snapshots__/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 4589
+- Update: main.LAST_HASH.hot-update.js, size: 4596
 
 ## Manifest
 
@@ -39,7 +39,7 @@ __webpack_require__.d(__webpack_exports__, {
 });
 /* ESM import */var _swc_helpers_sliced_to_array__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @swc/helpers/_/_sliced_to_array */ "../../../../node_modules/.pnpm/@swc+helpers@0.5.13/node_modules/@swc/helpers/esm/_sliced_to_array.js");
 /* ESM import */var react_jsx_dev_runtime__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react/jsx-dev-runtime */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/compat/jsx-dev-runtime.js");
-/* ESM import */var preact_hooks__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! preact/hooks */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/hooks/dist/hooks.js");
+/* ESM import */var preact_hooks__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! preact/hooks */ "../../../../node_modules/.pnpm/preact@10.24.3/node_modules/preact/hooks/dist/hooks.module.js");
 /* module decorator */ module = __webpack_require__.hmd(module);
 /* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../client/prefresh.cjs */ "../../../../client/prefresh.cjs");
 


### PR DESCRIPTION
1. Use `dirname(require.resolve('preact/package.json'))` to alias preact runtime modules. This change can allow users to use the ESM bundles of preact.
2. Use `/node_modules[\\/]preact[\\/]/` to exclude preact internal packages. This change can reduce rule conditions and improve build performance.