### PR TITLE
feat: add new `preactPath` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,38 +32,37 @@ The enabling of the [Preact Refresh](https://github.com/preactjs/prefresh) is di
     - Add [`@swc/plugin-prefresh`](https://github.com/swc-project/plugins/tree/main/packages/prefresh) into `jsc.experimental.plugins` to support the specific transformation of preact
   - Use `babel-loader` and add official [babel plugin](https://github.com/preactjs/prefresh/tree/main/packages/babel) of prefresh.
 
-
 > In versions below 1.0.0, Rspack did not support preact refresh with `swc-loader`.
 >
 > Please use `builtin:swc-loader` and enable preact specific transformation with `rspackExperiments.preact: {}`
 
 ```js
-const PreactRefreshPlugin = require('@rspack/plugin-preact-refresh');
-const isDev = process.env.NODE_ENV === 'development';
+const PreactRefreshPlugin = require("@rspack/plugin-preact-refresh");
+const isDev = process.env.NODE_ENV === "development";
 
 module.exports = {
   // ...
-  mode: isDev ? 'development' : 'production',
+  mode: isDev ? "development" : "production",
   module: {
     rules: [
       {
         test: /\.jsx$/,
         use: {
-          loader: 'builtin:swc-loader',
+          loader: "builtin:swc-loader",
           options: {
             jsc: {
               experimental: {
                 plugins: [
                   [
-                    '@swc/plugin-prefresh', // enable prefresh specific transformation
+                    "@swc/plugin-prefresh", // enable prefresh specific transformation
                     {
-                      library: ['preact-like-framework'], // the customizable preact name, default is `["preact", "preact/compat", "react"]`
+                      library: ["preact-like-framework"], // the customizable preact name, default is `["preact", "preact/compat", "react"]`
                     },
                   ],
                 ],
               },
               parser: {
-                syntax: 'ecmascript',
+                syntax: "ecmascript",
                 jsx: true,
               },
               transform: {
@@ -80,6 +79,23 @@ module.exports = {
   },
   plugins: [isDev && new PreactRefreshPlugin()].filter(Boolean),
 };
+```
+
+## Options
+
+### preactPath
+
+- Type: `string`
+- Default: `path.dirname(require.resolve('preact/package.json'))`
+
+Path to the `preact` package.
+
+```js
+const path = require("node:path");
+
+new PreactRefreshPlugin({
+  preactPath: path.dirname(require.resolve("preact/package.json")),
+});
 ```
 
 ## Example

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,17 @@ export interface IPreactRefreshRspackPluginOptions {
   overlay?: {
     module: string;
   };
+  /**
+   * Path to the `preact` package.
+   * @default `path.dirname(require.resolve('preact/package.json'))`
+   */
+  preactPath?: string;
 }
 
 interface NormalizedPluginOptions extends IPreactRefreshRspackPluginOptions {
   include: NonNullable<IPreactRefreshRspackPluginOptions['include']>;
   exclude: NonNullable<IPreactRefreshRspackPluginOptions['exclude']>;
+  preactPath: NonNullable<IPreactRefreshRspackPluginOptions['preactPath']>;
 }
 
 const PREFRESH_CORE_PATH = require.resolve('@prefresh/core');
@@ -33,6 +39,8 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
       include: options?.include ?? /\.([jt]sx?)$/,
       exclude: options?.exclude ?? /node_modules/,
       overlay: options?.overlay,
+      preactPath:
+        options?.preactPath ?? dirname(require.resolve('preact/package.json')),
     };
   }
 
@@ -42,8 +50,6 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
       compiler.options.mode === 'production'
     )
       return;
-
-    const PREACT_PATH = dirname(require.resolve('preact/package.json'));
 
     const INTERNAL_PATHS = [
       PREFRESH_UTILS_PATH,
@@ -66,7 +72,7 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
 
     // new compiler.webpack.DefinePlugin({ __refresh_library__ }).apply(compiler);
     compiler.options.resolve.alias = {
-      preact: PREACT_PATH,
+      preact: this.options.preactPath,
       '@prefresh/core': PREFRESH_CORE_PATH,
       '@prefresh/utils': PREFRESH_UTILS_PATH,
       ...compiler.options.resolve.alias,


### PR DESCRIPTION
Add a new `preactPath` option, this is useful in a monorepo to specify the correct `preact` package path.

```js
const path = require("node:path");

new PreactRefreshPlugin({
  preactPath: path.dirname(require.resolve("preact/package.json")),
});
```