### PR TITLE
fix: correct the type of `include` and `exclude` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ module.exports = {
 
 ## Options
 
+### include
+
+- Type: [Rspack.RuleSetCondition](https://rspack.dev/config/module#condition)
+- Default: `/\.([jt]sx?)$/`
+
+Include files to be processed by the plugin. The value is the same as the `rule.test` option in Rspack.
+
+```js
+new PreactRefreshPlugin({
+  include: [/\.jsx$/, /\.tsx$/],
+});
+```
+
+### exclude
+
+- Type: [Rspack.RuleSetCondition](https://rspack.dev/config/module#condition)
+- Default: `/node_modules/`
+
+Exclude files from being processed by the plugin. The value is the same as the `rule.exclude` option in Rspack.
+
+```js
+new PreactRefreshPlugin({
+  exclude: [/node_modules/, /some-other-module/],
+});
+```
+
 ### preactPath
 
 - Type: `string`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,31 @@
 import fs from 'node:fs';
 import { dirname } from 'node:path';
-import type { Compiler, RspackPluginInstance } from '@rspack/core';
+import type {
+  Compiler,
+  RspackPluginInstance,
+  RuleSetCondition,
+} from '@rspack/core';
 
 export interface IPreactRefreshRspackPluginOptions {
-  include?: string | RegExp | (string | RegExp)[] | null;
-  exclude?: string | RegExp | (string | RegExp)[] | null;
+  /**
+   * Include files to be processed by the plugin.
+   * The value is the same as the `rule.test` option in Rspack.
+   * @default /\.([jt]sx?)$/
+   */
+  include?: RuleSetCondition | null;
+  /**
+   * Exclude files from being processed by the plugin.
+   * The value is the same as the `rule.exclude` option in Rspack.
+   * @default /node_modules/
+   */
+  exclude?: RuleSetCondition | null;
+  /**
+   * Configure the error overlay.
+   */
   overlay?: {
+    /**
+     * The module to use for the error overlay.
+     */
     module: string;
   };
   /**


### PR DESCRIPTION
- Correct the type of `include` and `exclude` options, `Rspack.RuleSetCondition` is more accurate.
- Add these options to README.