### PR TITLE
fix: remove invalid intercept export

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
       "import": "./dist/index.js",
       "require": "./index.cjs"
     },
-    "./intercept": "./client/reactRefresh.js",
     "./prefresh": "./client/prefresh.js",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## Summary

This PR removes the `./intercept` export because it points to `./client/reactRefresh.js`, which is not included in the published package. The existing `./prefresh` export and package entry points are unchanged.