### PR TITLE
feat!: remove default plugin export

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The enabling of the [Preact Refresh](https://github.com/preactjs/prefresh) is di
 
 ```js
 import { createRequire } from 'node:module';
-import PreactRefreshPlugin from '@rspack/plugin-preact-refresh';
+import { PreactRefreshRspackPlugin } from '@rspack/plugin-preact-refresh';
 
 const require = createRequire(import.meta.url);
 const isDev = process.env.NODE_ENV === 'development';
@@ -82,7 +82,7 @@ export default {
       },
     ],
   },
-  plugins: [isDev && new PreactRefreshPlugin()].filter(Boolean),
+  plugins: [isDev && new PreactRefreshRspackPlugin()].filter(Boolean),
 };
 ```
 
@@ -96,7 +96,7 @@ export default {
 Include files to be processed by the plugin. The value is the same as the `rule.test` option in Rspack.
 
 ```js
-new PreactRefreshPlugin({
+new PreactRefreshRspackPlugin({
   include: [/\.jsx$/, /\.tsx$/],
 });
 ```
@@ -109,7 +109,7 @@ new PreactRefreshPlugin({
 Exclude files from being processed by the plugin. The value is the same as the `rule.exclude` option in Rspack.
 
 ```js
-new PreactRefreshPlugin({
+new PreactRefreshRspackPlugin({
   exclude: [/node_modules/, /some-other-module/],
 });
 ```
@@ -127,7 +127,7 @@ import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 
-new PreactRefreshPlugin({
+new PreactRefreshRspackPlugin({
   preactPath: path.dirname(require.resolve('preact/package.json')),
 });
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,4 +143,3 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
 }
 
 export { PreactRefreshRspackPlugin };
-export default PreactRefreshRspackPlugin;

--- a/test/configCases/condition/exclude/rspack.config.js
+++ b/test/configCases/condition/exclude/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -9,7 +7,7 @@ module.exports = {
   context: __dirname,
   entry: './index.js',
   plugins: [
-    new ReactRefreshRspackPlugin({
+    new PreactRefreshRspackPlugin({
       exclude: /file\.js/,
     }),
   ],

--- a/test/configCases/condition/include/rspack.config.js
+++ b/test/configCases/condition/include/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -9,7 +7,7 @@ module.exports = {
   context: __dirname,
   entry: './index.js',
   plugins: [
-    new ReactRefreshRspackPlugin({
+    new PreactRefreshRspackPlugin({
       exclude: /$^/, // match nothing
       include: /foo/,
     }),

--- a/test/hotCases/hook/useContext_initial/rspack.config.js
+++ b/test/hotCases/hook/useContext_initial/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -56,5 +54,5 @@ module.exports = {
       },
     ],
   },
-  plugins: [new ReactRefreshRspackPlugin()],
+  plugins: [new PreactRefreshRspackPlugin()],
 };

--- a/test/hotCases/hook/useContext_keep/rspack.config.js
+++ b/test/hotCases/hook/useContext_keep/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -56,5 +54,5 @@ module.exports = {
       },
     ],
   },
-  plugins: [new ReactRefreshRspackPlugin()],
+  plugins: [new PreactRefreshRspackPlugin()],
 };

--- a/test/hotCases/hook/useContext_provide/rspack.config.js
+++ b/test/hotCases/hook/useContext_provide/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -56,5 +54,5 @@ module.exports = {
       },
     ],
   },
-  plugins: [new ReactRefreshRspackPlugin()],
+  plugins: [new PreactRefreshRspackPlugin()],
 };

--- a/test/hotCases/hook/useState_keep/rspack.config.js
+++ b/test/hotCases/hook/useState_keep/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -56,5 +54,5 @@ module.exports = {
       },
     ],
   },
-  plugins: [new ReactRefreshRspackPlugin()],
+  plugins: [new PreactRefreshRspackPlugin()],
 };

--- a/test/hotCases/hook/useState_reset/rspack.config.js
+++ b/test/hotCases/hook/useState_reset/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -56,5 +54,5 @@ module.exports = {
       },
     ],
   },
-  plugins: [new ReactRefreshRspackPlugin()],
+  plugins: [new PreactRefreshRspackPlugin()],
 };

--- a/test/hotCases/jsx/basic/rspack.config.js
+++ b/test/hotCases/jsx/basic/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -55,5 +53,5 @@ module.exports = {
       },
     ],
   },
-  plugins: [new ReactRefreshRspackPlugin()],
+  plugins: [new PreactRefreshRspackPlugin()],
 };

--- a/test/hotCases/jsx/child/rspack.config.js
+++ b/test/hotCases/jsx/child/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -55,5 +53,5 @@ module.exports = {
       },
     ],
   },
-  plugins: [new ReactRefreshRspackPlugin()],
+  plugins: [new PreactRefreshRspackPlugin()],
 };

--- a/test/hotCases/jsx/value/rspack.config.js
+++ b/test/hotCases/jsx/value/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -55,5 +53,5 @@ module.exports = {
       },
     ],
   },
-  plugins: [new ReactRefreshRspackPlugin()],
+  plugins: [new PreactRefreshRspackPlugin()],
 };

--- a/test/hotCases/jsx/with-same-name-component/rspack.config.js
+++ b/test/hotCases/jsx/with-same-name-component/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -55,5 +53,5 @@ module.exports = {
       },
     ],
   },
-  plugins: [new ReactRefreshRspackPlugin()],
+  plugins: [new PreactRefreshRspackPlugin()],
 };

--- a/test/hotCases/with-worker/basic/rspack.config.js
+++ b/test/hotCases/with-worker/basic/rspack.config.js
@@ -1,6 +1,4 @@
-const {
-  default: ReactRefreshRspackPlugin,
-} = require('../../../../dist/index.js');
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
 
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
@@ -66,5 +64,5 @@ module.exports = {
       },
     },
   },
-  plugins: [new ReactRefreshRspackPlugin()],
+  plugins: [new PreactRefreshRspackPlugin()],
 };


### PR DESCRIPTION
## Summary

This PR changes the public plugin API to expose `PreactRefreshRspackPlugin` as the named runtime export and removes the package entry's plugin default export. The README and test configurations now consume the named export so the documented usage matches the actual public API.

## Breaking Changes

- `import PreactRefreshPlugin from '@rspack/plugin-preact-refresh'` no longer works.
- Consumers must migrate to `import { PreactRefreshRspackPlugin } from '@rspack/plugin-preact-refresh'`.
