### PR TITLE
feat!: add test option to preact refresh plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,31 @@ export default {
 
 ## Options
 
+### test
+
+- Type: [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
+- Default: `/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/`
+
+Specifies which files should be processed by the Preact Refresh loader. This option is passed to the `builtin:preact-refresh-loader` as the `rule.test` condition.
+
+Works identically to Rspack's [rule.test](https://rspack.rs/config/module-rules#rulestest) option.
+
+```js
+new PreactRefreshRspackPlugin({
+  test: [/\.jsx$/, /\.tsx$/],
+});
+```
+
 ### include
 
 - Type: [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
-- Default: `/\.([jt]sx?)$/`
+- Default: `undefined`
 
-Include files to be processed by the plugin. The value is the same as the `rule.test` option in Rspack.
+Explicitly includes files to be processed by the Preact Refresh loader. This option is passed to the `builtin:preact-refresh-loader` as the `rule.include` condition.
+
+Use this to limit processing to specific directories or file patterns.
+
+Works identically to Rspack's [rule.include](https://rspack.rs/config/module-rules#rulesinclude) option.
 
 ```js
 new PreactRefreshRspackPlugin({

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,10 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
       },
       use: 'builtin:preact-refresh-loader',
     };
-    if (this.options.include != null) {
+    if (
+      this.options.include !== null &&
+      typeof this.options.include !== 'undefined'
+    ) {
       refreshRule.include = this.options.include;
     }
     compiler.options.module.rules.unshift(refreshRule);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import type {
   Compiler,
   RspackPluginInstance,
   RuleSetCondition,
+  RuleSetRule,
 } from '@rspack/core';
 
 const require = createRequire(import.meta.url);
@@ -113,9 +114,8 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
       ...compiler.options.resolve.alias,
     };
 
-    compiler.options.module.rules.unshift({
+    const refreshRule: RuleSetRule = {
       test: this.options.test,
-      include: this.options.include!,
       exclude: {
         or: [
           this.options.exclude,
@@ -129,7 +129,11 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
         not: ['url'],
       },
       use: 'builtin:preact-refresh-loader',
-    });
+    };
+    if (this.options.include != null) {
+      refreshRule.include = this.options.include;
+    }
+    compiler.options.module.rules.unshift(refreshRule);
 
     compiler.hooks.thisCompilation.tap(NAME, (compilation) => {
       compilation.hooks.runtimeModule.tap(NAME, (runtimeModule) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,16 @@ const require = createRequire(import.meta.url);
 
 export interface IPreactRefreshRspackPluginOptions {
   /**
+   * Specifies which files should be processed by the Preact Refresh loader.
+   * This option is passed to the `builtin:preact-refresh-loader` as the `rule.test` condition.
+   * Works identically to Rspack's `rule.test` option.
+   * @default /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/
+   */
+  test?: RuleSetCondition;
+  /**
    * Include files to be processed by the plugin.
-   * The value is the same as the `rule.test` option in Rspack.
-   * @default /\.([jt]sx?)$/
+   * The value is the same as the `rule.include` option in Rspack.
+   * @default undefined
    */
   include?: RuleSetCondition | null;
   /**
@@ -38,8 +45,12 @@ export interface IPreactRefreshRspackPluginOptions {
   preactPath?: string;
 }
 
-interface NormalizedPluginOptions extends IPreactRefreshRspackPluginOptions {
-  include: NonNullable<IPreactRefreshRspackPluginOptions['include']>;
+interface NormalizedPluginOptions extends Omit<
+  IPreactRefreshRspackPluginOptions,
+  'test' | 'include' | 'exclude' | 'preactPath'
+> {
+  test: NonNullable<IPreactRefreshRspackPluginOptions['test']>;
+  include: IPreactRefreshRspackPluginOptions['include'];
   exclude: NonNullable<IPreactRefreshRspackPluginOptions['exclude']>;
   preactPath: NonNullable<IPreactRefreshRspackPluginOptions['preactPath']>;
 }
@@ -57,13 +68,14 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
   name = NAME;
   private options: NormalizedPluginOptions;
 
-  constructor(options: IPreactRefreshRspackPluginOptions) {
+  constructor(options: IPreactRefreshRspackPluginOptions = {}) {
     this.options = {
-      include: options?.include ?? /\.([jt]sx?)$/,
-      exclude: options?.exclude ?? /node_modules/,
-      overlay: options?.overlay,
+      test: options.test ?? /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/,
+      include: options.include,
+      exclude: options.exclude ?? /node_modules/,
+      overlay: options.overlay,
       preactPath:
-        options?.preactPath ?? dirname(require.resolve('preact/package.json')),
+        options.preactPath ?? dirname(require.resolve('preact/package.json')),
     };
   }
 
@@ -102,7 +114,8 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
     };
 
     compiler.options.module.rules.unshift({
-      include: this.options.include,
+      test: this.options.test,
+      include: this.options.include!,
       exclude: {
         or: [
           this.options.exclude,

--- a/test/configCases/condition/default-test/file.mjs
+++ b/test/configCases/condition/default-test/file.mjs
@@ -1,0 +1,1 @@
+export const value = 'mjs';

--- a/test/configCases/condition/default-test/index.js
+++ b/test/configCases/condition/default-test/index.js
@@ -1,0 +1,7 @@
+require('./file.mjs');
+
+it('should process mjs files with default test', () => {
+  expect(
+    __webpack_modules__[require.resolve('./file.mjs')].toString(),
+  ).toContain('__prefresh_utils__');
+});

--- a/test/configCases/condition/default-test/rspack.config.js
+++ b/test/configCases/condition/default-test/rspack.config.js
@@ -1,0 +1,10 @@
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'web',
+  context: __dirname,
+  entry: './index.js',
+  plugins: [new PreactRefreshRspackPlugin()],
+};

--- a/test/configCases/condition/include-null/file.js
+++ b/test/configCases/condition/include-null/file.js
@@ -1,0 +1,1 @@
+module.exports = 'include-null';

--- a/test/configCases/condition/include-null/index.js
+++ b/test/configCases/condition/include-null/index.js
@@ -1,0 +1,7 @@
+require('./file');
+
+it('should omit null include when compiling', () => {
+  expect(
+    __webpack_modules__[require.resolve('./file.js')].toString(),
+  ).toContain('__prefresh_utils__');
+});

--- a/test/configCases/condition/include-null/rspack.config.js
+++ b/test/configCases/condition/include-null/rspack.config.js
@@ -1,0 +1,14 @@
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'web',
+  context: __dirname,
+  entry: './index.js',
+  plugins: [
+    new PreactRefreshRspackPlugin({
+      include: null,
+    }),
+  ],
+};

--- a/test/configCases/condition/test/file.js
+++ b/test/configCases/condition/test/file.js
@@ -1,0 +1,1 @@
+require('foo');

--- a/test/configCases/condition/test/index.js
+++ b/test/configCases/condition/test/index.js
@@ -1,0 +1,7 @@
+require('./file');
+
+it('should test selected file when compiling', () => {
+  expect(__webpack_modules__[require.resolve('foo')].toString()).toContain(
+    '__prefresh_utils__',
+  );
+});

--- a/test/configCases/condition/test/rspack.config.js
+++ b/test/configCases/condition/test/rspack.config.js
@@ -1,0 +1,15 @@
+const { PreactRefreshRspackPlugin } = require('../../../../dist/index.js');
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'web',
+  context: __dirname,
+  entry: './index.js',
+  plugins: [
+    new PreactRefreshRspackPlugin({
+      exclude: /$^/, // match nothing
+      test: /foo/,
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary

This PR adds a `test` option to `@rspack/plugin-preact-refresh` so loader matching can be configured separately from `include`, matching `@rspack/plugin-react-refresh`. It also aligns the defaults by moving the extension matcher to `test` and leaving `include` undefined unless explicitly configured.

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm test`