### PR TITLE
fix: tighten default node_modules exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ new PreactRefreshRspackPlugin({
 ### exclude
 
 - Type: [Rspack.RuleSetCondition](https://rspack.rs/config/module-rules#condition)
-- Default: `/node_modules/`
+- Default: `/[\\/]node_modules[\\/]/`
 
 Exclude files from being processed by the plugin. The value is the same as the `rule.exclude` option in Rspack.
 
 ```js
 new PreactRefreshRspackPlugin({
-  exclude: [/node_modules/, /some-other-module/],
+  exclude: [/[\\/]node_modules[\\/]/, /some-other-module/],
 });
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export interface IPreactRefreshRspackPluginOptions {
   /**
    * Exclude files from being processed by the plugin.
    * The value is the same as the `rule.exclude` option in Rspack.
-   * @default /node_modules/
+   * @default /[\\/]node_modules[\\/]/
    */
   exclude?: RuleSetCondition | null;
   /**
@@ -73,7 +73,7 @@ class PreactRefreshRspackPlugin implements RspackPluginInstance {
     this.options = {
       test: options.test ?? /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/,
       include: options.include,
-      exclude: options.exclude ?? /node_modules/,
+      exclude: options.exclude ?? /[\\/]node_modules[\\/]/,
       overlay: options.overlay,
       preactPath:
         options.preactPath ?? dirname(require.resolve('preact/package.json')),

--- a/test/configCases/condition/default-test/index.js
+++ b/test/configCases/condition/default-test/index.js
@@ -1,7 +1,16 @@
 require('./file.mjs');
+require('./not_node_modules/file.js');
 
 it('should process mjs files with default test', () => {
   expect(
     __webpack_modules__[require.resolve('./file.mjs')].toString(),
+  ).toContain('__prefresh_utils__');
+});
+
+it('should only exclude node_modules path segments by default', () => {
+  expect(
+    __webpack_modules__[
+      require.resolve('./not_node_modules/file.js')
+    ].toString(),
   ).toContain('__prefresh_utils__');
 });

--- a/test/configCases/condition/default-test/not_node_modules/file.js
+++ b/test/configCases/condition/default-test/not_node_modules/file.js
@@ -1,0 +1,1 @@
+module.exports = 'not node_modules';


### PR DESCRIPTION
## Summary

This PR tightens the default Preact Refresh `exclude` condition to match only `node_modules` path segments on POSIX and Windows paths. It also updates the README default and adds a config case covering a path segment that only contains `node_modules` as a substring.

## Validation

- `pnpm lint`
- `pnpm test`