### PR TITLE
fix: add rspack core peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 
 Preact refresh plugin for [Rspack](https://github.com/web-infra-dev/rspack).
 
+## Versions
+
+- `2.x`: For Rspack v2.
+- `1.x`: For Rspack v1, see [v1.x - README](https://github.com/rstackjs/rspack-plugin-preact-refresh/tree/v1.x?tab=readme-ov-file#rspackplugin-preact-refresh) for usage guide.
+
 ## Installation
 
 First you need to install the dependencies:

--- a/package.json
+++ b/package.json
@@ -58,7 +58,13 @@
   },
   "peerDependencies": {
     "@prefresh/core": "^1.5.0",
-    "@prefresh/utils": "^1.2.0"
+    "@prefresh/utils": "^1.2.0",
+    "@rspack/core": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    }
   },
   "packageManager": "pnpm@11.5.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary

This PR declares `@rspack/core` as an optional peer dependency so package consumers get the expected Rspack compatibility metadata without requiring this package to install Rspack directly. It also documents the package version compatibility split between Rspack v2 and v1.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`
- `git diff --check`